### PR TITLE
Fixed null select keys to correctly trigger trackers using only skill keys

### DIFF
--- a/D2RSO/Classes/Data/SkillDataItem.cs
+++ b/D2RSO/Classes/Data/SkillDataItem.cs
@@ -60,7 +60,7 @@ namespace D2RSO.Classes.Data
         public bool SkillKeyPressed()
         {
             //initial state with no select key
-            if (_state == 0 && SelectKey == null)
+            if (_state == 0 && SelectKey.Code == null)
                 return true;
             //already pressed select
             if (_state == 1)

--- a/D2RSO/MainWindow.xaml.cs
+++ b/D2RSO/MainWindow.xaml.cs
@@ -206,7 +206,8 @@ namespace D2RSO
                     }
 
                     result = SelectedSkillItems.Where(a =>
-                        a.IsEnabled && a.SelectKey != null &&
+                        a.IsEnabled && a.SelectKey != null && 
+                        a.SelectKey.Code != null &&
                         a.SelectKey.Code.Equals(loggedKey, StringComparison.OrdinalIgnoreCase)).ToList();
                     if (result.Any())
                     {


### PR DESCRIPTION
When using the following option in D2R, you do not need to provide a 'select' key as skills are cast immediately when using the skill input, so instead trackers should immediately be toggled when the skill key is pressed. 

This behaviour wasn't happening, when debugging I found SkillDataItem.cs needed a tiny update to fix it - however then found a null reference occurring afterwards which I also fixed.  Thx for your efforts on this project 🚀 

![image](https://user-images.githubusercontent.com/13265482/223349248-da186532-3277-4adc-be14-cf1cd8f355e7.png)
